### PR TITLE
Pack into a single file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Examples/~$4 TabColors.xlsx
 /Cx_Freeze_Energy_Diagram_Plotter.py
 /build/
 /dist/
+/Draw_Energy_Diagram_XML/*
+*.spec

--- a/Draw_Energy_Diagram_XML.py
+++ b/Draw_Energy_Diagram_XML.py
@@ -23,15 +23,11 @@ import sys
 import os
 import math
 import copy
-import shutil
 import re
 import time
-import subprocess
 from openpyxl import load_workbook
 import random
-from datetime import datetime
 import ctypes
-import numpy as np
 
 number_font_size = 17
 tag_font_size = 17

--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -28,12 +28,13 @@ include_folders = ["UI", "Examples"]
 include_files = ["__matplotlib_DPI_Manual_Setting.txt"]
 delete_files = []
 
-generated_folder_name = os.path.join('dist', filename_class(main_py_file).name_stem)
-os.mkdir(os.path.join(generated_folder_name))
+generated_folder_name = filename_class(main_py_file).name_stem
+if not os.path.exists(generated_folder_name):    
+    os.mkdir(generated_folder_name)
 
 PyInstaller.__main__.run([
     main_py_file,
-    "-i", icon, '-n', os.path.join(generated_folder_name, generated_exe_name), '-y', '-F', '--clean'
+    '-i', icon, '-n', generated_exe_name, '-y', '-F', '-w', '-p', '.\\Python_Lib', '--clean'
 ])
 
 
@@ -60,6 +61,7 @@ def copy_folder(src, dst):
 for file in include_files:
     print(f"Copying {file} to {generated_folder_name}")
     shutil.copy(file, generated_folder_name)
+shutil.copy(os.path.join('dist', generated_exe_name), generated_folder_name)
 
 for folder in include_folders:
     copy_folder(folder, generated_folder_name)

--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -1,16 +1,8 @@
 # -*- coding: utf-8 -*-
 __author__ = 'LiYuanhe'
 
-import sys
 import os
-import math
-import copy
 import shutil
-import re
-import time
-import random
-import subprocess
-from collections import OrderedDict
 
 # import pathlib
 # parent_path = str(pathlib.Path(__file__).parent.resolve())

--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -24,30 +24,16 @@ main_py_file = 'Draw_Energy_Diagram_XML.py'
 generated_exe_name = "__Energy Diagram Plotter CDXML 3.5.exe"
 icon = r"UI\Draw_Energy_Diagram_Icon.ico"
 include_all_folder_contents = []
-include_folders = ["UI", "Python_Lib","Examples",r"C:\Anaconda3\Lib\site-packages\setuptools"]
-include_files = ["Draw_Energy_Diagram_XML.bat",
-                 "__matplotlib_DPI_Manual_Setting.txt"]
-delete_files = ["Qt5WebEngineCore.dll",
-                "mkl_avx512.1.dll",
-                "mkl_avx.1.dll",
-                "mkl_mc3.1.dll",
-                "mkl_avx2.1.dll",
-                "mkl_mc.1.dll",
-                "mkl_tbb_thread.1.dll",
-                "mkl_sequential.1.dll",
-                "mkl_vml_avx.1.dll",
-                "mkl_vml_mc.1.dll",
-                "mkl_vml_avx2.1.dll",
-                "mkl_vml_mc3.1.dll",
-                "mkl_vml_mc2.1.dll",
-                "mkl_vml_avx512.1.dll",
-                "mkl_vml_def.1.dll",
-                "mkl_vml_cmpt.1.dll"]
+include_folders = ["UI", "Examples"]
+include_files = ["__matplotlib_DPI_Manual_Setting.txt"]
+delete_files = []
 
+generated_folder_name = os.path.join('dist', filename_class(main_py_file).name_stem)
+os.mkdir(os.path.join(generated_folder_name))
 
 PyInstaller.__main__.run([
     main_py_file,
-    "--icon",icon, '-y'
+    "-i", icon, '-n', os.path.join(generated_folder_name, generated_exe_name), '-y', '-F', '--clean'
 ])
 
 
@@ -71,18 +57,15 @@ def copy_folder(src, dst):
     shutil.copytree(src, target)
 
 
-generated_folder_name = os.path.join('dist',filename_class(main_py_file).name_stem)
-
-
 for file in include_files:
     print(f"Copying {file} to {generated_folder_name}")
-    shutil.copy(file,generated_folder_name)
+    shutil.copy(file, generated_folder_name)
 
 for folder in include_folders:
     copy_folder(folder, generated_folder_name)
 
 for file in delete_files:
-    file = os.path.join(generated_folder_name,file)
+    file = os.path.join(generated_folder_name, file)
     if os.path.isfile(file):
         print(f"Deleting {file}")
         os.remove(file)
@@ -97,8 +80,5 @@ for folder in include_all_folder_contents:
             shutil.copy(current_object, generated_folder_name)
         else:
             copy_folder(current_object, generated_folder_name)
-
-shutil.move(os.path.join(generated_folder_name,filename_class(main_py_file).name_stem+'.exe'),
-            os.path.join(generated_folder_name,generated_exe_name))
 
 open_explorer_and_select(os.path.realpath(generated_folder_name))


### PR DESCRIPTION
大佬的小工具非常好用，解了燃眉之急。由于一直用的 `PySide6` 所以就懒得装 `PyQt5` 了，直接下的release版。但是文件实在是太多了，不太优雅。看了下是 `pyinstaller.py` 没写好，于是做了点微小的工作：

-  `PyInstaller` 自带了一个 `-F` 指令，来生成单一的可执行文件。`-n` 可以用来指定生成文件的文件名。`--clean` 可以清除临时文件。如果不要cmd的话还可以加上一个 `-w`，不确定大佬需不需要就先没加。

-  > 因为我实在懒得挑该附哪些库，所以全扔进去了。

    其实一个都不用扔，都打包进去了。

- `Draw_Energy_Diagram_XML.bat` 在打包之后应该用不到了。

- 格式化了一下代码。

由于没装 `PyQt5` 也就没有调试，逻辑上应该是没问题的，大佬可以试试。

再次感谢大佬的小工具~